### PR TITLE
Add formatter.

### DIFF
--- a/moz_sql_parser/__init__.py
+++ b/moz_sql_parser/__init__.py
@@ -18,6 +18,7 @@ from mo_future import text_type, number_types, binary_type, items
 from pyparsing import ParseException, ParseResults
 
 from moz_sql_parser.sql_parser import SQLParser, all_exceptions
+from moz_sql_parser.formatting import Formatter
 
 
 def parse(sql):
@@ -34,6 +35,10 @@ def parse(sql):
             raise ParseException(sql, e.loc, "Expecting one of (" + (", ".join(expecting)) + ")")
         raise
     return _scrub(parse_result)
+
+
+def format(json, **kwargs):
+    return Formatter(**kwargs).format(json)
 
 
 def _scrub(result):

--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -1,0 +1,242 @@
+# encoding: utf-8
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Author: Beto Dealmeida (beto@dealmeida.net)
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+import re
+
+from six import string_types, text_type
+
+from moz_sql_parser.sql_parser import RESERVED
+
+
+VALID = re.compile(r'[a-zA-Z_]\w*')
+
+
+def should_quote(identifier):
+    """
+    Return true if a given identifier should be quoted.
+
+    This is usually true when the identifier:
+
+      - is a reserved word
+      - contain spaces
+      - does not match the regex `[a-zA-Z_]\w*`
+
+    """
+    return (
+        identifier != '*' and (
+            not VALID.match(identifier) or identifier in RESERVED))
+
+
+def escape(identifier, ansi_quotes, should_quote):
+    """
+    Escape identifiers.
+
+    ANSI uses single quotes, but many databases use back quotes.
+
+    """
+    if not should_quote(identifier):
+        return identifier
+
+    quote = '"' if ansi_quotes else '`'
+    identifier = identifier.replace(quote, 2*quote)
+    return '{0}{1}{2}'.format(quote, identifier, quote)
+
+
+def Operator(op, parentheses=False):
+    op = ' {0} '.format(op)
+    def func(self, json):
+        out = op.join(self.dispatch(v) for v in json)
+        if parentheses:
+            out = '({0})'.format(out)
+        return out
+    return func
+
+
+class Formatter:
+
+    clauses = [
+        'select',
+        'from_',
+        'where',
+        'groupby',
+        'having',
+        'orderby',
+        'limit',
+        'offset',
+    ]
+
+    # simple operators
+    _concat = Operator('||')
+    _mult = Operator('*')
+    _div = Operator('/', parentheses=True)
+    _add = Operator('+')
+    _sub = Operator('-', parentheses=True)
+    _neq = Operator('<>')
+    _gt = Operator('>')
+    _lt = Operator('<')
+    _gte = Operator('>=')
+    _lte = Operator('<=')
+    _eq = Operator('=')
+    _or = Operator('OR')
+    _and = Operator('AND')
+
+    def __init__(self, ansi_quotes=True, should_quote=should_quote):
+        self.ansi_quotes = ansi_quotes
+        self.should_quote = should_quote
+
+    def format(self, json):
+        if 'union' in json:
+            return self.union(json['union'])
+        else:
+            return self.query(json)
+
+    def dispatch(self, json):
+        if isinstance(json, list):
+            return self.delimited_list(json)
+        if isinstance(json, dict):
+            if 'value' in json:
+                return self.value(json)
+            else:
+                return self.op(json)
+        if isinstance(json, string_types):
+            return escape(json, self.ansi_quotes, self.should_quote)
+        
+        return text_type(json)
+
+    def delimited_list(self, json):
+        return ', '.join(self.dispatch(element) for element in json)
+
+    def value(self, json):
+        parts = [self.dispatch(json['value'])]
+        if 'name' in json:
+            parts.extend(['AS', self.dispatch(json['name'])])
+        return ' '.join(parts)
+
+    def op(self, json):
+        if 'on' in json:
+            return self._on(json)
+
+        if len(json) > 1:
+            raise Exception('Operators should have only one key!')
+        key, value = list(json.items())[0]
+
+        # check if the attribute exists, and call the corresponding method;
+        # note that we disallow keys that start with `_` to avoid giving access
+        # to magic methods
+        attr = '_{0}'.format(key)
+        if hasattr(self, attr) and not key.startswith('_'):
+            method = getattr(self, attr)
+            return method(value)
+
+        return '{0}({1})'.format(key.upper(), value)
+
+    def _exists(self, value):
+        return '{0} IS NOT NULL'.format(self.dispatch(value))
+
+    def _missing(self, value):
+        return '{0} IS NULL'.format(self.dispatch(value))
+
+    def _like(self, pair):
+        return '{0} LIKE {1}'.format(self.dispatch(pair[0]), self.dispatch(pair[1]))
+
+    def _is(self, pair):
+        return '{0} IS {1}'.format(self.dispatch(pair[0]), self.dispatch(pair[1]))
+
+    def _in(self, json):
+        valid = self.dispatch(json[1])
+        # `(10, 11, 12)` does not get parsed as literal, so it's formatted as
+        # `10, 11, 12`. This fixes it.
+        if not valid.startswith('('):
+            valid = '({0})'.format(valid)
+
+        return '{0} IN {1}'.format(json[0], valid)
+
+    def _case(self, checks):
+        parts = ['CASE']
+        for check in checks:
+            if isinstance(check, dict):
+                parts.extend(['WHEN', self.dispatch(check['when'])])
+                parts.extend(['THEN', self.dispatch(check['then'])])
+            else:
+                parts.extend(['ELSE', self.dispatch(check)])
+        parts.append('END')
+        return ' '.join(parts)
+
+    def _literal(self, json):
+        if isinstance(json, list):
+            return '({0})'.format(', '.join(self._literal(v) for v in json))
+        elif isinstance(json, string_types):
+            return "'{0}'".format(json.replace("'", "''"))
+        else:
+            return str(json)
+
+    def _on(self, json):
+        return 'JOIN {0} ON {1}'.format(
+            self.dispatch(json['join']), self.dispatch(json['on']))
+
+    def union(self, json):
+        return ' UNION '.join(self.query(query) for query in json)
+
+    def query(self, json):
+        parts = []
+        for clause in self.clauses:
+            method = getattr(self, clause, None)
+            if method:
+                parts.append(method(json))
+        return ' '.join(part for part in parts if part)
+
+    def select(self, json):
+        if 'select' in json:
+            return 'SELECT {0}'.format(self.dispatch(json['select']))
+
+    def from_(self, json):
+        is_join = False
+        if 'from' in json:
+            from_ = json['from']
+            if not isinstance(from_, list):
+                from_ = [from_]
+
+            parts = []
+            for token in from_:
+                if 'join' in token:
+                    is_join = True
+                parts.append(self.dispatch(token))
+            joiner = ' ' if is_join else ', '
+            rest = joiner.join(parts)
+            return 'FROM {0}'.format(rest)
+
+    def where(self, json):
+        if 'where' in json:
+            return 'WHERE {0}'.format(self.dispatch(json['where']))
+
+    def groupby(self, json):
+        if 'groupby' in json:
+            return 'GROUP BY {0}'.format(self.dispatch(json['groupby']))
+
+    def having(self, json):
+        if 'having' in json:
+            return 'HAVING {0}'.format(self.dispatch(json['having']))
+
+    def orderby(self, json):
+        if 'orderby' in json:
+            sort = json['orderby'].get('sort', '').upper()
+            return 'ORDER BY {0} {1}'.format(
+                self.dispatch(json['orderby']), sort).strip()
+
+    def limit(self, json):
+        if 'limit' in json:
+            return 'LIMIT {0}'.format(self.dispatch(json['limit']))
+
+    def offset(self, json):
+        if 'offset' in json:
+            return 'OFFSET {0}'.format(self.dispatch(json['offset']))

--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -61,6 +61,7 @@ keywords = [
     "is",
     "join",
     "limit",
+    "offset",
     "like",
     "on",
     "or",
@@ -322,14 +323,16 @@ selectStmt << Group(
                     Optional(WHERE.suppress().setDebugActions(*debug) + expr.setName("where"))("where") +
                     Optional(GROUPBY.suppress().setDebugActions(*debug) + delimitedList(Group(selectColumn))("groupby").setName("groupby")) +
                     Optional(HAVING.suppress().setDebugActions(*debug) + expr("having").setName("having")) +
-                    Optional(LIMIT.suppress().setDebugActions(*debug) + expr("limit"))
+                    Optional(LIMIT.suppress().setDebugActions(*debug) + expr("limit")) +
+                    Optional(OFFSET.suppress().setDebugActions(*debug) + expr("offset"))
                 )
             ),
             delim=UNION
         )
     )("union"))("from") +
     Optional(ORDERBY.suppress().setDebugActions(*debug) + delimitedList(Group(sortColumn))("orderby").setName("orderby")) +
-    Optional(LIMIT.suppress().setDebugActions(*debug) + expr("limit"))
+    Optional(LIMIT.suppress().setDebugActions(*debug) + expr("limit")) +
+    Optional(OFFSET.suppress().setDebugActions(*debug) + expr("offset"))
 ).addParseAction(to_union_call)
 
 

--- a/setup.py
+++ b/setup.py
@@ -50,7 +50,7 @@ setup(
     url='https://github.com/mozilla/moz-sql-parser',
     license='MPL 2.0',
     packages=find_packages(".", lib_prefix=""),
-    install_requires=["mo-future>=2.18.18240","pyparsing"],
+    install_requires=["mo-future>=2.18.18240","pyparsing","six"],
     include_package_data=True,
     zip_safe=False,
     classifiers=[  #https://pypi.python.org/pypi?%3Aaction=list_classifiers

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -1,0 +1,322 @@
+# encoding: utf-8
+#
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this file,
+# You can obtain one at http://mozilla.org/MPL/2.0/.
+#
+# Author: Beto Dealmeida (beto@dealmeida.net)
+#
+
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import unicode_literals
+
+from unittest import skip
+from unittest import TestCase
+
+from moz_sql_parser import format
+from moz_sql_parser import parse
+from moz_sql_parser import sql_parser
+
+
+class TestSimple(TestCase):
+
+    def test_two_tables(self):
+        result = format({
+            "select": "*",
+            "from": ["XYZZY", "ABC"]
+        })
+        expected = "SELECT * FROM XYZZY, ABC"
+        self.assertEqual(result, expected)
+
+    def test_dot_table_name(self):
+        result = format({
+            "select": "*",
+            "from": "SYS.XYZZY",
+        })
+        expected = "SELECT * FROM SYS.XYZZY"
+        self.assertEqual(result, expected)
+
+    def select_one_column(self):
+        result = format({
+            "select": [{"value": "A"}],
+            "from": ["dual"],
+        })
+        expected = "SELECT A FROM dual"
+        self.assertEqual(result, expected)
+
+    def test_select_quote(self):
+        result = format({
+            "select": {"value": {"literal": "'"}},
+            "from": "dual",
+        })
+        expected = "SELECT '''' FROM dual"
+        self.assertEqual(result, expected)
+
+    def test_select_quoted_name(self):
+        result = format({
+            "select": [
+                {"name": "@*#&", "value": "a"},
+                {"name": "test.g.g.c", "value": "b"}
+            ],
+            "from": "dual",
+        })
+        expected = 'SELECT a AS "@*#&", b AS test.g.g.c FROM dual'
+        self.assertEqual(result, expected)
+
+    def test_select_expression(self):
+        result = format({
+            "select": {"value": {"add": [
+                "a",
+                {"div": ["b", 2]},
+                {"mult": [45, "c"]},
+                {"div": [2, "d"]},
+            ]}},
+            "from": "dual",
+        })
+        expected = "SELECT a + (b / 2) + 45 * c + (2 / d) FROM dual"
+        self.assertEqual(result, expected)
+
+    def test_select_underscore_name(self):
+        result = format({
+            "select": {"value": "_id"},
+            "from": "dual",
+        })
+        expected = "SELECT _id FROM dual"
+        self.assertEqual(result, expected)
+
+    def test_select_dots_names(self):
+        result = format({
+            "select": {"value": "a.b.c._d"},
+            "from": "dual",
+        })
+        expected = "SELECT a.b.c._d FROM dual"
+        self.assertEqual(result, expected)
+
+    def select_many_column(self):
+        result = format({
+            "select": [
+                {"value": "a"},
+                {"value": "b"},
+                {"value": "c"},
+            ],
+            "from": ["dual"],
+        })
+        expected = "SELECT a, b, c FROM dual"
+        self.assertEqual(result, expected)
+
+    def test_where_neq(self):
+        result = format({
+            "select": "*",
+            "from": "dual",
+            "where": {"neq": ["a", {"literal": "test"}]},
+        })
+        expected = "SELECT * FROM dual WHERE a <> 'test'"
+        self.assertEqual(result, expected)
+
+    def test_where_in(self):
+        result = format({
+            "select": {"value": "a"},
+            "from": "dual",
+            "where": {"in": [
+                "a",
+                {"literal": ["r", "g", "b"]},
+            ]},
+        })
+        expected = "SELECT a FROM dual WHERE a IN ('r', 'g', 'b')"
+        self.assertEqual(result, expected)
+
+    def test_where_in_and_in(self):
+        result = format({
+            "select": {"value": "a"},
+            "from": "dual",
+            "where": {"and": [
+                {"in": [
+                    "a",
+                    {"literal": ["r", "g", "b"]},
+                ]},
+                {"in": [
+                    "b",
+                    [10, 11, 12],
+                ]},
+            ]},
+        })
+        expected = "SELECT a FROM dual WHERE a IN ('r', 'g', 'b') AND b IN (10, 11, 12)"
+        self.assertEqual(result, expected)
+
+    def test_eq(self):
+        result = format({
+            "select": [
+                {"value": "a"},
+                {"value": "b"},
+            ],
+            "from": ["t1", "t2"],
+            "where": {"eq": ["t1.a", "t2.b"]},
+        })
+        expected = "SELECT a, b FROM t1, t2 WHERE t1.a = t2.b"
+        self.assertEqual(result, expected)
+
+    def test_is_null(self):
+        result = format({
+            "select": [
+                {"value": "a"},
+                {"value": "b"},
+            ],
+            "from": "t1",
+            "where": {"missing": "t1.a"},
+        })
+        expected = "SELECT a, b FROM t1 WHERE t1.a IS NULL"
+        self.assertEqual(result, expected)
+
+    def test_is_not_null(self):
+        result = format({
+            "select": [
+                {"value": "a"},
+                {"value": "b"},
+            ],
+            "from": "t1",
+            "where": {"exists": "t1.a"},
+        })
+        expected = "SELECT a, b FROM t1 WHERE t1.a IS NOT NULL"
+        self.assertEqual(result, expected)
+
+    def test_groupby(self):
+        result = format({
+            "select": [
+                {"value": "a"},
+                {"name": "b", "value": {"count": 1}},
+            ],
+            "from": "mytable",
+            "groupby": {"value": "a"},
+        })
+        expected = "SELECT a, COUNT(1) AS b FROM mytable GROUP BY a"
+        self.assertEqual(result, expected)
+
+    def test_function(self):
+        result = format({
+            "select": {"value": {"count": 1}},
+            "from": "mytable",
+        })
+        expected = "SELECT COUNT(1) FROM mytable"
+        self.assertEqual(result, expected)
+
+    def test_order_by(self):
+        result = format({
+            "select": {"value": {"count": 1}},
+            "from": "dual",
+            "orderby": {"value": "a"},
+        })
+        expected = "SELECT COUNT(1) FROM dual ORDER BY a"
+        self.assertEqual(result, expected)
+
+    def test_order_by_asc(self):
+        result = format({
+            "select": {"value": {"count": 1}},
+            "from": "dual",
+            "orderby": {"value": "a", "sort": "asc"},
+        })
+        expected = "SELECT COUNT(1) FROM dual ORDER BY a ASC"
+        self.assertEqual(result, expected)
+
+    def test_neg_or_precedence(self):
+        result = format({
+            'from': 'table1',
+            'where': {'or': [{'eq': ['A', -900]}, {'eq': ['B', 100]}]},
+            'select': [{'value': 'B'}, {'value': 'C'}],
+        })
+        expected = "SELECT B, C FROM table1 WHERE A = -900 OR B = 100"
+        self.assertEqual(result, expected)
+
+    def test_negative_number(self):
+        result = format({
+            'from': 'table1',
+            'where': {'eq': ['A', -900]},
+            'select': {'value': 'a'},
+        })
+        expected = "SELECT a FROM table1 WHERE A = -900"
+        self.assertEqual(result, expected)
+
+    def test_like_in_where(self):
+        result = format({
+            'from': 'table1',
+            'where': {'like': ['A', {"literal": "%20%"}]},
+            'select': {'value': 'a'},
+        })
+        expected = "SELECT a FROM table1 WHERE A LIKE '%20%'"
+        self.assertEqual(result, expected)
+
+    def test_like_in_select(self):
+        result = format({
+            'from': 'table1',
+            'select': {'name': 'bb', 'value': {"case": [{"when": {"like": ["A", {"literal": "bb%"}]}, "then": 1}, 0]}},
+        })
+        expected = "SELECT CASE WHEN A LIKE 'bb%' THEN 1 ELSE 0 END AS bb FROM table1"
+        self.assertEqual(result, expected)
+
+    def test_like_from_pr16(self):
+        result = format({
+            'from': 'trade',
+            'where': {"and": [
+                {"like": ["school", {"literal": "%shool"}]},
+                {"eq": ["name", {"literal": "abc"}]},
+                {"in": ["id", {"literal": ["1", "2"]}]},
+            ]},
+            'select': "*",
+        })
+        expected = "SELECT * FROM trade WHERE school LIKE '%shool' AND name = 'abc' AND id IN ('1', '2')"
+        self.assertEqual(result, expected)
+
+    def test_in_expression(self):
+        result = format({
+            'from': 'task',
+            'select': "*",
+            "where": {"in": [
+                "repo.branch.name",
+                {"literal": ["try", "mozilla-central"]},
+            ]},
+        })
+        expected = "SELECT * FROM task WHERE repo.branch.name IN ('try', 'mozilla-central')"
+        self.assertEqual(result, expected)
+
+    def test_joined_table_name(self):
+        result = format({
+            'from': [
+                {'name': 't1', 'value': 'table1'},
+                {'on': {'eq': ['t1.id', 't3.id']}, 'join': {'name': 't3', 'value': 'table3'}},
+            ],
+            'select': '*',
+        })
+        expected = "SELECT * FROM table1 AS t1 JOIN table3 AS t3 ON t1.id = t3.id"
+        self.assertEqual(result, expected)
+
+    def test_not_equal(self):
+        result = format({
+            'select': '*',
+            'from': "task",
+            "where": {"and": [
+                {"exists": "build.product"},
+                {"neq": ["build.product", {"literal": "firefox"}]},
+            ]},
+        })
+        expected = "SELECT * FROM task WHERE build.product IS NOT NULL AND build.product <> 'firefox'"
+        self.assertEqual(result, expected)
+
+    def test_union(self):
+        result = format({
+            'union': [
+                {'select': '*', 'from': 'a'},
+                {'select': '*', 'from': 'b'},
+            ],
+        })
+        expected = "SELECT * FROM a UNION SELECT * FROM b"
+        self.assertEqual(result, expected)
+
+    def test_limit(self):
+        result = format({'select': '*', 'from': 'a', 'limit': 10})
+        expected = "SELECT * FROM a LIMIT 10"
+        self.assertEqual(result, expected)
+
+    def test_offset(self):
+        result = format({'select': '*', 'from': 'a', 'limit': 10, 'offset': 10})
+        expected = "SELECT * FROM a LIMIT 10 OFFSET 10"
+        self.assertEqual(result, expected)


### PR DESCRIPTION
I created a new file for generating SQL back from the parsed JSON. The unit tests from the parser were adapted to check for the inverse operation, and a few others were added.

While at it, I added support for `OFFSET`. I know it's not standard SQL, but since neither is the supported `LIMIT` I thought it wouldn't matter (and I really need my parser to be able to understand `OFFSET`).

Let me know if I should sign a contributor license agreement. I added my name as the author in the files I created, let me know if that's ok or if I should add your name since you're the lead developer.

This PR fixes https://github.com/mozilla/moz-sql-parser/issues/9.

