### PR TITLE
Improvements to SQL formatter

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -188,12 +188,12 @@ class Formatter:
         return ' UNION '.join(self.query(query) for query in json)
 
     def query(self, json):
-        parts = []
-        for clause in self.clauses:
-            method = getattr(self, clause, None)
-            if method:
-                parts.append(method(json))
-        return ' '.join(part for part in parts if part)
+        return ' '.join(
+            part
+            for clause in self.clauses
+            for part in [getattr(self, clause)(json)]
+            if part
+        )
 
     def select(self, json):
         if 'select' in json:

--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -138,7 +138,7 @@ class Formatter:
             method = getattr(self, attr)
             return method(value)
 
-        return '{0}({1})'.format(key.upper(), value)
+        return '{0}({1})'.format(key.upper(), self.dispatch(value))
 
     def _exists(self, value):
         return '{0} IS NOT NULL'.format(self.dispatch(value))

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -320,3 +320,8 @@ class TestSimple(TestCase):
         result = format({'select': '*', 'from': 'a', 'limit': 10, 'offset': 10})
         expected = "SELECT * FROM a LIMIT 10 OFFSET 10"
         self.assertEqual(result, expected)
+
+    def test_count_literal(self):
+        result = format({'select': {'value': {'count': {'literal': 'literal'}}}, 'from': 'a'})
+        expected = "SELECT COUNT('literal') FROM a"
+        self.assertEqual(result, expected)


### PR DESCRIPTION
This PR rewrites the `query` method in the formatter to use a list comprehension. It also fixes a bug where the values of operators were not processed (I've added a unit test capturing the bug).