### PR TITLE
Fix functions without arguments in formatter

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -104,7 +104,9 @@ class Formatter:
         if isinstance(json, list):
             return self.delimited_list(json)
         if isinstance(json, dict):
-            if 'value' in json:
+            if len(json) == 0:
+                return ''
+            elif 'value' in json:
                 return self.value(json)
             else:
                 return self.op(json)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -325,3 +325,8 @@ class TestSimple(TestCase):
         result = format({'select': {'value': {'count': {'literal': 'literal'}}}, 'from': 'a'})
         expected = "SELECT COUNT('literal') FROM a"
         self.assertEqual(result, expected)
+
+    def test_no_arguments(self):
+        result = format({'select': {'value': {'now': {}}}})
+        expected = "SELECT NOW()"
+        self.assertEqual(result, expected)


### PR DESCRIPTION
A small quick fix for functions without arguments like `NOW()`. Added a unit test covering the problem.