### PR TITLE
Added support for parsing other JOIN types (FULL, RIGHT, LEFT OUTER, etc)

### DIFF
--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -54,6 +54,8 @@ keywords = [
     "else",
     "end",
     "from",
+    "full join",
+    "full outer join",
     "group by",
     "having",
     "in",
@@ -61,12 +63,15 @@ keywords = [
     "is",
     "join",
     "left join",
+    "left outer join",
     "limit",
     "offset",
     "like",
     "on",
     "or",
     "order by",
+    "right join",
+    "right outer join",
     "select",
     "then",
     "union",
@@ -308,7 +313,7 @@ tableName = (
     ident.setName("table name").setDebugActions(*debug)
 )
 
-join = ((CROSSJOIN | INNERJOIN | LEFTJOIN | JOIN)("op") + Group(tableName)("join") + Optional(ON + expr("on"))).addParseAction(to_join_call)
+join = ((CROSSJOIN | FULLJOIN | FULLOUTERJOIN | INNERJOIN | JOIN | LEFTJOIN | LEFTOUTERJOIN | RIGHTJOIN | RIGHTOUTERJOIN)("op") + Group(tableName)("join") + Optional(ON + expr("on"))).addParseAction(to_join_call)
 
 sortColumn = expr("value").setName("sort1").setDebugActions(*debug) + Optional(DESC("sort") | ASC("sort")) | \
              expr("value").setName("sort2").setDebugActions(*debug)

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -386,3 +386,38 @@ class TestSimple(FuzzyTestCase):
             "limit": NULL
         }
         self.assertEqual(result, expected)
+
+    def test_left_outer_join(self):
+        result = parse("SELECT t1.field1 FROM t1 LEFT OUTER JOIN t2 ON t1.id = t2.id")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'left outer join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
+        self.assertEqual(result, expected)
+
+    def test_right_join(self):
+        result = parse("SELECT t1.field1 FROM t1 RIGHT JOIN t2 ON t1.id = t2.id")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'right join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
+        self.assertEqual(result, expected)
+
+    def test_right_outer_join(self):
+        result = parse("SELECT t1.field1 FROM t1 RIGHT OUTER JOIN t2 ON t1.id = t2.id")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'right outer join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
+        self.assertEqual(result, expected)
+
+    def test_full_join(self):
+        result = parse("SELECT t1.field1 FROM t1 FULL JOIN t2 ON t1.id = t2.id")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'full join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
+        self.assertEqual(result, expected)
+
+    def test_full_outer_join(self):
+        result = parse("SELECT t1.field1 FROM t1 FULL OUTER JOIN t2 ON t1.id = t2.id")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'full outer join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
+        self.assertEqual(result, expected)


### PR DESCRIPTION
Previously, the parser did not recognize all of the standard JOINs, such as RIGHT JOIN, RIGHT OUTER JOIN, LEFT OUTER JOIN, FULL JOIN, and FULL OUTER JOIN.  This PR adds support for these, as well as some simple test cases to test their parsing. 

Notes:
- For the test cases, I simply duplicated `test_simple.test_left_join`, swapping the new join types accordingly and putting the new functions in `test_simple.py`.  Let me know if you prefer these in `test_resources.py` instead (or if it would be better to just merge these into one function with a while loop).
- In the JSON output, "LEFT OUTER JOIN" becomes "left outer join", and "LEFT JOIN" remains "left join".  I could see how some might prefer "LEFT OUTER JOIN" to become "left join" since it is the same thing.  I left it as is since it keeps the PR changes simple and the behavior preference will be pretty subjective.