### PR TITLE
Added support for JOINs with USING syntax

### DIFF
--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -320,8 +320,7 @@ tableName = (
 join = (
     (CROSSJOIN | FULLJOIN | FULLOUTERJOIN | INNERJOIN | JOIN | LEFTJOIN | LEFTOUTERJOIN | RIGHTJOIN | RIGHTOUTERJOIN)("op") +
     Group(tableName)("join") +
-    Optional(ON + expr("on")) +
-    Optional(USING + expr("using"))
+    Optional((ON + expr("on")) | (USING + expr("using")))
 ).addParseAction(to_join_call)
 
 sortColumn = expr("value").setName("sort1").setDebugActions(*debug) + Optional(DESC("sort") | ASC("sort")) | \

--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -76,6 +76,7 @@ keywords = [
     "then",
     "union",
     "union all",
+    "using",
     "when",
     "where",
     "with"
@@ -188,6 +189,9 @@ def to_join_call(instring, tokensStart, retTokens):
 
     if tok.on:
         output['on'] = tok.on
+
+    if tok.using:
+        output['using'] = tok.using
     return output
 
 
@@ -313,7 +317,12 @@ tableName = (
     ident.setName("table name").setDebugActions(*debug)
 )
 
-join = ((CROSSJOIN | FULLJOIN | FULLOUTERJOIN | INNERJOIN | JOIN | LEFTJOIN | LEFTOUTERJOIN | RIGHTJOIN | RIGHTOUTERJOIN)("op") + Group(tableName)("join") + Optional(ON + expr("on"))).addParseAction(to_join_call)
+join = (
+    (CROSSJOIN | FULLJOIN | FULLOUTERJOIN | INNERJOIN | JOIN | LEFTJOIN | LEFTOUTERJOIN | RIGHTJOIN | RIGHTOUTERJOIN)("op") +
+    Group(tableName)("join") +
+    Optional(ON + expr("on")) +
+    Optional(USING + expr("using"))
+).addParseAction(to_join_call)
 
 sortColumn = expr("value").setName("sort1").setDebugActions(*debug) + Optional(DESC("sort") | ASC("sort")) | \
              expr("value").setName("sort2").setDebugActions(*debug)
@@ -348,4 +357,3 @@ SQLParser = selectStmt
 oracleSqlComment = Literal("--") + restOfLine
 mySqlComment = Literal("#") + restOfLine
 SQLParser.ignore(oracleSqlComment | mySqlComment)
-

--- a/tests/test_errors.py
+++ b/tests/test_errors.py
@@ -22,3 +22,9 @@ class TestErrors(TestCase):
             ["group by", "order by", "having", "limit", "where"],
             lambda: parse("select * from coverage-summary.source.file.covered limit 20")
         )
+
+    def test_join_on_using_together(self):
+        assertRaises(
+            "Expecting one of",
+            lambda: parse("SELECT * FROM t1 JOIN t2 ON t1.id=t2.id USING (id)")
+        )

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -416,4 +416,9 @@ class TestSimple(TestCase):
                     {'full outer join': 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
         self.assertEqual(result, expected)
 
-
+    def test_join_via_using(self):
+        result = parse("SELECT t1.field1 FROM t1 JOIN t2 USING (id)")
+        expected = {'select': {'value': 't1.field1'},
+                    'from': ['t1',
+                    {'join': 't2', 'using': 'id'}]}
+        self.assertEqual(result, expected)


### PR DESCRIPTION
This PR adds support for `USING` in join statements. For example:

```sql
SELECT * FROM table1 INNER JOIN table2 USING (id)
```

This would result in `{'join': 'table2', 'using': 'id'}` being added to the `from` list.

This addresses #50 