### PR TITLE
Added not-between operator support

### DIFF
--- a/moz_sql_parser/sql_parser.py
+++ b/moz_sql_parser/sql_parser.py
@@ -59,7 +59,6 @@ keywords = [
     "group by",
     "having",
     "in",
-    "not in",
     "inner join",
     "is",
     "join",
@@ -68,6 +67,8 @@ keywords = [
     "limit",
     "offset",
     "like",
+    "not between",
+    "not in",
     "not like",
     "on",
     "or",
@@ -93,6 +94,7 @@ RESERVED = MatchFirst(reserved)
 
 KNOWN_OPS = [
     (BETWEEN, AND),
+    (NOTBETWEEN, AND),
     Literal("||").setName("concat").setDebugActions(*debug),
     Literal("*").setName("mul").setDebugActions(*debug),
     Literal("/").setName("div").setDebugActions(*debug),

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -448,3 +448,21 @@ class TestSimple(TestCase):
                     'from': ['t1',
                     {'join': 't2', 'using': 'id'}]}
         self.assertEqual(result, expected)
+
+    def test_where_between(self):
+        result = parse("SELECT a FROM dual WHERE a BETWEEN 1 and 2")
+        expected = {
+            "select": {"value": "a"},
+            "from": "dual",
+            "where": {"between": ["a", 1, 2]}
+        }
+        self.assertEqual(result, expected)
+
+    def test_where_not_between(self):
+        result = parse("SELECT a FROM dual WHERE a NOT BETWEEN 1 and 2")
+        expected = {
+            "select": {"value": "a"},
+            "from": "dual",
+            "where": {"not between": ["a", 1, 2]}
+        }
+        self.assertEqual(result, expected)


### PR DESCRIPTION
This PR adds support for `NOT BETWEEN` SQL, such as:

```sql
SELECT a FROM dual WHERE a NOT BETWEEN 1 and 2
```

The operator name returned from the parser is currently `not between`, which differs from `NOT LIKE` and `NOT IN`, who are respectively labeled as `nlike` and `nin`.  I didn't see an obvious way to change this, but if you see an easy way to do so, let me know.