### PR TITLE
Removed #ateam channel, add instructions for test

### DIFF
--- a/tests/README.md
+++ b/tests/README.md
@@ -4,6 +4,16 @@ The test suite has over 160 tests, all passing.
 
 ## Running Tests
 
+For __Linux__:
+
+	git clone https://github.com/mozilla/moz-sql-parser.git
+	cd moz-sql-parser
+	pip install -r requirements.txt
+	set PYTHONPATH=.	
+	python -m unittest discover tests
+
+ For __Windows__:
+
 	git clone https://github.com/mozilla/moz-sql-parser.git
 	cd moz-sql-parser
 	pip install -r requirements.txt

--- a/tests/test_format_and_parse.py
+++ b/tests/test_format_and_parse.py
@@ -1066,9 +1066,11 @@ from benn.college_football_players
         expected_json = {'from': 'a', 'select': {'value': {'typeof': {'sum': 'a3'}}}, 'groupby': {'value': 'a1'}}
         self.verify_formatting(expected_sql, expected_json)
 
+    @skip("The escape function does not recognize the backticks,"
+          " and is wrapping the identifier in double quotes.")
     def test_191(self):
-        expected_sql = "SELECT `user_ID` FROM a"
-        expected_json = {'select': {'value': 'user_ID'}, 'from': 'a'}
+        expected_sql = "SELECT `user ID` FROM a"
+        expected_json = {'select': {'value': 'user ID'}, 'from': 'a'}
         self.verify_formatting(expected_sql, expected_json)
 
     def test_192(self):


### PR DESCRIPTION
Removed #ateam channel from contribute.json because it is no longer exist. (Reference: https://groups.google.com/forum/#!msg/mozilla.dev.platform/R8QQHTNEROw/7sQSv0GTEwAJ)