### PR TITLE
Add mo-files in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 mo-future>=2.20
+mo-files>=2.31
 pyparsing


### PR DESCRIPTION
In the program, we used module mo-files, but we couldn't update it in the requirements.txt.

Reference: https://github.com/mozilla/moz-sql-parser/blob/dev/moz_sql_parser/__init__.py#L23