### PR TITLE
Pin mo_future to <3

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-mo-future>=2.46
+mo-future>=2.46,<3
 pyparsing==2.3.1


### PR DESCRIPTION
Version 3 of `mo_future` is incompatible:
```
Traceback (most recent call last):
  File "main.py", line 20, in <module>
    from moz_sql_parser import parse
  File "/usr/local/lib/python3.7/site-packages/moz_sql_parser/__init__.py", line 16, in <module>
    from mo_future import binary_type, items, number_types, text_type
ImportError: cannot import name 'text_type' from 'mo_future' (/usr/local/lib/python3.7/site-packages/mo_future/__init__.py)
```