### PR TITLE
Parsing and formatting CASE is broken

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -15,7 +15,7 @@ import re
 
 from mo_future import string_types, text, first, long, is_text
 
-from moz_sql_parser.keywords import RESERVED, join_keywords, precedence, binary_ops
+from moz_sql_parser.keywords import RESERVED, RESERVED2, join_keywords, precedence, binary_ops
 
 VALID = re.compile(r'^[a-zA-Z_]\w*$')
 
@@ -33,7 +33,7 @@ def should_quote(identifier):
     """
     return (
         identifier != '*' and (
-            not VALID.match(identifier) or identifier in RESERVED))
+            not VALID.match(identifier) or identifier in RESERVED2))
 
 
 def split_field(field):
@@ -244,8 +244,11 @@ class Formatter:
         parts = ['CASE']
         for check in checks:
             if isinstance(check, dict):
-                parts.extend(['WHEN', self.dispatch(check['when'])])
-                parts.extend(['THEN', self.dispatch(check['then'])])
+                if 'when' in check and 'then' in check:
+                    parts.extend(['WHEN', self.dispatch(check['when'])])
+                    parts.extend(['THEN', self.dispatch(check['then'])])
+                else:
+                    parts.extend(['ELSE', self.dispatch(check)])
             else:
                 parts.extend(['ELSE', self.dispatch(check)])
         parts.append('END')

--- a/moz_sql_parser/keywords.py
+++ b/moz_sql_parser/keywords.py
@@ -52,6 +52,8 @@ for name, v in list(locs.items()):
         n = name.lower().replace("_", " ")
         value = locs[name] = Keyword(n, caseless=True).setName(n).setDebugActions(*debug)
         reserved.append(value)
+
+RESERVED2 = reserved
 RESERVED = MatchFirst(reserved)
 
 join_keywords = {

--- a/tests/test_format_and_parse.py
+++ b/tests/test_format_and_parse.py
@@ -1088,3 +1088,7 @@ from benn.college_football_players
             expected_json = {'select': {'value': 't1.field1'},
                              'from': ['t1', {join_keyword: 't2', 'on': {'eq': ['t1.id', 't2.id']}}]}
             self.verify_formatting(expected_sql, expected_json)
+
+    def test_193(self):
+        expected_sql = "SELECT id, CASE WHEN id < 13 THEN 'child' WHEN id < 20 THEN 'teenager' ELSE 'adult' END AS id_range FROM users"
+        self.assertEqual(expected_sql, format(parse(expected_sql)))

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -856,7 +856,7 @@ class TestSimple(TestCase):
         }
         self.assertEqual(result, expected)
 
-    @skipIf(not IS_MASTER, "Takes too long, and does not test net new features")
+    #@skipIf(not IS_MASTER, "Takes too long, and does not test net new features")
     def test_issue_103(self):
         #        0         1         2         3         4         5         6         7         8         9
         #        012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
@@ -877,7 +877,7 @@ class TestSimple(TestCase):
         expected = {"select": {"value": {"in": ["a", ["abc", 3, {"literal": 'def'}]]}}}
         self.assertEqual(result, expected)
 
-    #@skipIf(IS_MASTER, "stack too deep")
+    @skipIf(IS_MASTER, "stack too deep")
     def test_issue_107_recursion(self):
         sql = (
             " SELECT city_name"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -13,7 +13,7 @@ import json
 from unittest import TestCase, skipIf
 
 from moz_sql_parser import parse
-from test_resources import IS_MASTER
+from .test_resources import IS_MASTER
 
 try:
     from tests.util import assertRaises
@@ -856,7 +856,7 @@ class TestSimple(TestCase):
         }
         self.assertEqual(result, expected)
 
-    # @skipIf(not IS_MASTER, "Takes too long, and does not test net new features")
+    @skipIf(not IS_MASTER, "Takes too long, and does not test net new features")
     def test_issue_103(self):
         #        0         1         2         3         4         5         6         7         8         9
         #        012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789
@@ -877,7 +877,7 @@ class TestSimple(TestCase):
         expected = {"select": {"value": {"in": ["a", ["abc", 3, {"literal": 'def'}]]}}}
         self.assertEqual(result, expected)
 
-    @skipIf(IS_MASTER, "stack too deep")
+    #@skipIf(IS_MASTER, "stack too deep")
     def test_issue_107_recursion(self):
         sql = (
             " SELECT city_name"

--- a/tests/test_simple.py
+++ b/tests/test_simple.py
@@ -13,7 +13,7 @@ import json
 from unittest import TestCase, skipIf
 
 from moz_sql_parser import parse
-from .test_resources import IS_MASTER
+from test_resources import IS_MASTER
 
 try:
     from tests.util import assertRaises


### PR DESCRIPTION
Hello,

We have noticed that when parsing a CASE statement and reformatting the parsed output, the code throws an exception.

We noticed that the format function would not work with simple quote marks on the CASE clause in the THEN part. We have pushed a solution, but as we do not understand what the MatchFirst does, it might not be the best solution.