### PR TITLE
Add support for newer pyparsing versions

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -33,7 +33,7 @@ def should_quote(identifier):
     """
     return (
         identifier != '*' and (
-            not VALID.match(identifier) or identifier in RESERVED))
+            not VALID.match(identifier) or len(list(RESERVED.scanString(identifier)))))
 
 
 def split_field(field):

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ setup(
     long_description_content_type=u'text/markdown',
     include_package_data=True,
     classifiers=["Development Status :: 3 - Alpha","Topic :: Software Development :: Libraries","Topic :: Software Development :: Libraries :: Python Modules","Programming Language :: SQL","Programming Language :: Python :: 2.7","Programming Language :: Python :: 3.6","License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"],
-    install_requires=["mo-future>=3.31.20024","pyparsing==2.3.1"],
+    install_requires=["mo-future>=3.31.20024","pyparsing>=2.3.1,<=2.4.7"],
     version=u'3.32.20026',
     url=u'https://github.com/mozilla/moz-sql-parser',
     zip_safe=True,


### PR DESCRIPTION
This adds support for pyparsing up to the current version 2.4.7 while keeping support for currently pinned 2.3.1.

Resolves issue #128