### PR TITLE
Added support for WITH CTE clauses

### DIFF
--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -112,6 +112,7 @@ def Operator(op):
 class Formatter:
 
     clauses = [
+        'with_',
         'select',
         'from_',
         'where',
@@ -179,6 +180,7 @@ class Formatter:
     def value(self, json):
         parts = [self.dispatch(json['value'])]
         if 'name' in json:
+            print(json)
             parts.extend(['AS', self.dispatch(json['name'])])
         return ' '.join(parts)
 
@@ -294,6 +296,17 @@ class Formatter:
             for part in [getattr(self, clause)(json)]
             if part
         )
+
+    def with_(self, json):
+        if 'with' in json:
+            with_ = json['with']
+            if not isinstance(with_, list):
+                with_ = [with_]
+            parts = ', '.join(
+                '{0} AS {1}'.format(part['name'], self.dispatch(part['value']))
+                for part in with_
+            )
+            return 'WITH {0}'.format(parts)
 
     def select(self, json):
         if 'select' in json:

--- a/moz_sql_parser/formatting.py
+++ b/moz_sql_parser/formatting.py
@@ -180,7 +180,6 @@ class Formatter:
     def value(self, json):
         parts = [self.dispatch(json['value'])]
         if 'name' in json:
-            print(json)
             parts.extend(['AS', self.dispatch(json['name'])])
         return ' '.join(parts)
 

--- a/tests/test_format_and_parse.py
+++ b/tests/test_format_and_parse.py
@@ -209,6 +209,19 @@ from benn.college_football_players
                          'select': '*'}
         self.verify_formatting(expected_sql, expected_json)
 
+    def test_with_cte(self):
+        expected_sql = "WITH t AS (SELECT a FROM table) SELECT * FROM t"
+        expected_json = {'select': '*', 'from': 't', 'with': {'name': 
+                         't', 'value': {'select': {'value': 'a'}, 'from': 'table'}}}
+        self.verify_formatting(expected_sql, expected_json)
+
+    def test_with_cte_various(self):
+        expected_sql = "WITH t1 AS (SELECT a FROM table), t2 AS (SELECT 1) SELECT * FROM t1, t2"
+        expected_json = {'select': '*', 'from': ['t1', 't2'], 
+                         'with': [{'name': 't1', 'value': {'select': {'value': 'a'}, 'from': 'table'}}, 
+                                  {'name': 't2', 'value': {'select': {'value': 1}}}]}
+        self.verify_formatting(expected_sql, expected_json)
+
     @skip("Not sure why")
     def test_not_equal(self):
         expected_sql = "select * from task where build.product is not null and build.product!='firefox'"

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -402,3 +402,17 @@ class TestSimple(TestCase):
             ]
         })
         self.assertEqual(result, expected)
+
+    def test_with_cte(self):
+        expected = "WITH t AS (SELECT a FROM table) SELECT * FROM t"
+        result = format({'select': '*', 'from': 't', 'with': {'name': 
+                         't', 'value': {'select': {'value': 'a'}, 'from': 'table'}}
+                        })
+        self.assertEqual(result, expected)
+
+    def test_with_cte(self):
+        expected = "WITH t1 AS (SELECT a FROM table), t2 AS (SELECT 1) SELECT * FROM t1, t2"
+        result = format({'select': '*', 'from': ['t1', 't2'], 
+                         'with': [{'name': 't1', 'value': {'select': {'value': 'a'}, 'from': 'table'}}, 
+                                  {'name': 't2', 'value': {'select': {'value': 1}}}]})
+        self.assertEqual(result, expected)

--- a/tests/test_formatting.py
+++ b/tests/test_formatting.py
@@ -410,7 +410,7 @@ class TestSimple(TestCase):
                         })
         self.assertEqual(result, expected)
 
-    def test_with_cte(self):
+    def test_with_cte_various(self):
         expected = "WITH t1 AS (SELECT a FROM table), t2 AS (SELECT 1) SELECT * FROM t1, t2"
         result = format({'select': '*', 'from': ['t1', 't2'], 
                          'with': [{'name': 't1', 'value': {'select': {'value': 'a'}, 'from': 'table'}}, 


### PR DESCRIPTION
This PR includes support for queries using WITH CTE like:

```
WITH t1 AS 
  (SELECT a FROM table) 
   , t2 AS (SELECT 1) 
SELECT * FROM t1, t2
```

In addition, some tests have been included in some suites to check this new behavior.