### PR TITLE
Import mapping from collections.abc

### DIFF
--- a/moz_sql_parser/__init__.py
+++ b/moz_sql_parser/__init__.py
@@ -9,7 +9,7 @@
 
 from __future__ import absolute_import, division, unicode_literals
 
-from collections import Mapping
+from collections.abc import Mapping
 import json
 from threading import Lock
 


### PR DESCRIPTION
Fixing this warning:
  ...\moz_sql_parser\__init__.py:12: DeprecationWarning: Using or importing the ABCs from 'collections' instead of from 'collections.abc' is deprecated since Python 3.3,and in 3.9 it will stop working
    from collections import Mapping