### PR TITLE
fix: unpin pyparsing for better cross dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,10 @@ setup(
     long_description_content_type=u'text/markdown',
     include_package_data=True,
     classifiers=["Development Status :: 3 - Alpha","Topic :: Software Development :: Libraries","Topic :: Software Development :: Libraries :: Python Modules","Programming Language :: SQL","Programming Language :: Python :: 2.7","Programming Language :: Python :: 3.6","License :: OSI Approved :: Mozilla Public License 2.0 (MPL 2.0)"],
-    install_requires=["mo-future>=3.31.20024","pyparsing==2.3.1"],
+    install_requires=[
+        "mo-future>=3.31.20024",
+        "pyparsing>=2.3.1, <3.0.0"
+    ],
     version=u'3.32.20026',
     url=u'https://github.com/mozilla/moz-sql-parser',
     zip_safe=True,


### PR DESCRIPTION
Hi,

Not sure if it's a hard pin, but it would be great to unpin and follow semver regarding `pyparsing` dependency.

Thank you!
